### PR TITLE
removed types that broke compilation

### DIFF
--- a/guiTool/include/types.h
+++ b/guiTool/include/types.h
@@ -5,12 +5,10 @@
 typedef unsigned char u8;
 typedef unsigned short u16;
 typedef unsigned long u32;
-typedef unsigned __int64 u64;
 
 typedef signed char s8;
 typedef signed short s16;
 typedef signed long s32;
-typedef __int64 s64;
 
 typedef unsigned char bool;
 


### PR DESCRIPTION
guiTool doesn't need the types I took out, and it won't compile with them in.